### PR TITLE
Add haptic.duration support and defaults for QtFeedback effects

### DIFF
--- a/50-droid-vibrator.ini
+++ b/50-droid-vibrator.ini
@@ -1,7 +1,7 @@
 [droid-vibrator]
 
 # For each string in EFFECT_LIST define a sequence
-EFFECT_LIST = touch,short,strong,long,notice,message,attention,alarm,ringtone,default
+EFFECT_LIST = drag_start,release_weak,drag_fail,drag_boundary,touch_weak,drag_end,release,touch,release_strong,touch_strong,short,strong,long,notice,message,attention,alarm,ringtone,default
 
 # Sequence has following syntax:
 #  sequence_name = <action>=<value>
@@ -15,13 +15,22 @@ EFFECT_LIST = touch,short,strong,long,notice,message,attention,alarm,ringtone,de
 # vibra = on=200,pause=100,repeat=1
 #
 
-touch    = on=20
-short    = on=33
-strong   = on=66
-long     = on=800
-notice   = on=100,pause=500,repeat=1
-message  = on=200,pause=200,repeat=1
-attention= on=100,pause=100,repeat=2
-alarm    = on=1000,pause=500,repeat=forever
-ringtone = on=2000,pause=500,repeat=forever
-default  = on=66
+drag_start     = on=5
+release_weak   = on=7
+drag_fail      = on=9
+drag_boundary  = on=10
+touch_weak     = on=10
+drag_end       = on=15
+release        = on=18
+touch          = on=20
+release_strong = on=25
+touch_strong   = on=30
+short          = on=33
+strong         = on=66
+long           = on=800
+notice         = on=100,pause=500,repeat=1
+message        = on=200,pause=200,repeat=1
+attention      = on=100,pause=100,repeat=2
+alarm          = on=1000,pause=500,repeat=forever
+ringtone       = on=2000,pause=500,repeat=forever
+default        = on=66


### PR DESCRIPTION
Add haptic.duration support. If haptic.duration is defined, repeat
the effect until it has run out and stop after that. Since most effects
consist of only single vibrations, detect that and play them for
the whole remaining duration.

Add values for QtFeedback effects.

See also https://github.com/sailfishos/ngfd/pull/2