### PR TITLE
native-vibrator: Add support for state path

### DIFF
--- a/src/implementation.h
+++ b/src/implementation.h
@@ -10,6 +10,7 @@
 #define IMPLEMENTATION_DESCRIPTION      "Haptic feedback using droid vibrator device"
 #define NATIVE_FILE_DURATION_PATH_KEY   "native.path"
 #define NATIVE_FILE_ACTIVATE_PATH_KEY   "native.activate_path"
+#define NATIVE_FILE_STATE_PATH_KEY      "native.state_path"
 
 #else
 


### PR DESCRIPTION
LED Transient Trigger interface has a state path and some vibrator drivers require it to be in correct state or else the vibrator can end up being enabled forever.

For customizing the state path native.state_path can be used.